### PR TITLE
Use Any in types checking

### DIFF
--- a/src/main/java/org/scijava/ops/types/Any.java
+++ b/src/main/java/org/scijava/ops/types/Any.java
@@ -1,0 +1,17 @@
+package org.scijava.ops.types;
+
+import java.lang.reflect.Type;
+
+/**
+ * This {@link Type} represents a Type that can be assigned to any other Type.
+ * 
+ * @author Gabe Selzer
+ *
+ */
+public class Any implements Type {
+	@Override
+	public String toString() {
+		return "Any";
+	}
+
+}

--- a/src/main/java/org/scijava/ops/types/TypeExtractor.java
+++ b/src/main/java/org/scijava/ops/types/TypeExtractor.java
@@ -68,7 +68,7 @@ public interface TypeExtractor<T> extends SingletonPlugin {
 		final Type[] types = new Type[typeVars.length];
 		for (int i = 0; i < types.length; i++) {
 			types[i] = reify(o, i);
-			if (types[i] == null) types[i] = Types.wildcard();
+			if (types[i] == null) types[i] = new Any();
 		}
 		return Types.parameterize(getRawType(), types);
 	}

--- a/src/main/java/org/scijava/ops/types/TypeService.java
+++ b/src/main/java/org/scijava/ops/types/TypeService.java
@@ -154,7 +154,7 @@ public interface TypeService extends
 
 		// fill in any remaining unresolved type parameters with wildcards
 		for (final TypeVariable<?> typeVar : typeVars) {
-			resolved.putIfAbsent(typeVar, Types.wildcard());
+			resolved.putIfAbsent(typeVar, new Any());
 		}
 
 		// now apply all the type variables we resolved

--- a/src/test/java/org/scijava/ops/types/AnyTest.java
+++ b/src/test/java/org/scijava/ops/types/AnyTest.java
@@ -1,0 +1,130 @@
+package org.scijava.ops.types;
+
+import java.lang.reflect.Type;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.scijava.core.Priority;
+import org.scijava.ops.AbstractTestEnvironment;
+import org.scijava.ops.core.Op;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+
+public class AnyTest extends AbstractTestEnvironment {
+
+	@Test
+	public void testAny() {
+
+		NestedThing<String, Thing<String>> nthing = new NestedThing<>();
+		Double e = (Double) ops().run("test.nestedAny", nthing);
+
+		Thing<Double> thing = new Thing<>();
+		Double d = (Double) ops().run("test.any", thing);
+
+		assert d == 5.;
+		assert e == 5.;
+
+	}
+
+	/**
+	 * NOTE: this is where ops.run() and the Any paradigm fail. However, this can
+	 * easily be avoided by making TypeExtractors for any class for which this kind
+	 * of exception can happen.
+	 */
+	@Test(expected = ClassCastException.class)
+	public void testExceptionalThing() {
+
+		ExceptionalThing<Double> ething = new ExceptionalThing<>(0.5);
+		Double d = (Double) ops().run("test.exceptionalAny", ething);
+
+	}
+
+	@Plugin(type = TypeExtractor.class, priority = Priority.LOW)
+	public static class ThingTypeExtractor implements TypeExtractor<Thing<?>> {
+
+		@Override
+		public Type reify(final Thing<?> o, final int n) {
+			if (n != 0)
+				throw new IndexOutOfBoundsException();
+
+			return new Any();
+		}
+
+		@Override
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		public Class<Thing<?>> getRawType() {
+			return (Class) Thing.class;
+		}
+
+	}
+
+}
+
+class Thing<U> {
+
+	public double create(U u) {
+		return 5.;
+	}
+}
+
+class ExceptionalThing<U> {
+
+	public ExceptionalThing(U u) {
+		thing = u;
+	};
+
+	U thing;
+
+	U getU() {
+		return thing;
+	}
+
+	public double create(U u) {
+		thing = u;
+		return 5.;
+	}
+}
+
+class NestedThing<U, V extends Thing<?>> {
+	public double create(V u) {
+		return 5.;
+	}
+}
+
+@Plugin(type = Op.class, name = "test.any")
+@Parameter(key = "thing")
+@Parameter(key = "output", type = ItemIO.OUTPUT)
+class ThingFunction implements Function<Thing<String>, Double> {
+
+	@Override
+	public Double apply(Thing<String> t) {
+		return t.create("Hello");
+	}
+
+}
+
+@Plugin(type = Op.class, name = "test.exceptionalAny")
+@Parameter(key = "thing")
+@Parameter(key = "output", type = ItemIO.OUTPUT)
+class ExceptionalThingFunction implements Function<ExceptionalThing<String>, Double> {
+
+	@Override
+	public Double apply(ExceptionalThing<String> t) {
+		String s = t.getU();
+		return t.create("Hello");
+	}
+
+}
+
+@Plugin(type = Op.class, name = "test.nestedAny")
+@Parameter(key = "nestedThing")
+@Parameter(key = "output", type = ItemIO.OUTPUT)
+class NestedThingFunction implements Function<NestedThing<String, Thing<String>>, Double> {
+
+	@Override
+	public Double apply(NestedThing<String, Thing<String>> t) {
+		return 5.;
+	}
+
+}


### PR DESCRIPTION
This PR introduces the `Any` type, a type designed to be assignable to any other type. In practice `Any`s will only ever occur when the user calls `ops.run()` (since if they use `ops.findOp()` or some helper variant they will be using `Nil`s) and `Any`s should never be specifyed by the user. The purpose of `Any` is as a hack to allow non-reifiable type parameters (such as those of [`OutOfBoundsFactory`](https://github.com/imglib/imglib2/blob/62287fbcbba520da5d4ed9ab30d2f3264e5faa1a/src/main/java/net/imglib2/outofbounds/OutOfBoundsFactory.java#L44)) to pass matching. In practice this is a safe behavior, since if type parameters are non-reifiable they will never throw `ClassCastException`s. If the type parameters are reifiable then they can be reified using a `TypeExtractor`.

**TODO:**
* More tests?
* Code cleanup? This might, however, might be worth waiting on until we have smoothed more bugs out of the matcher.
