### PR TITLE
Restrict Ops to single output

### DIFF
--- a/src/main/java/org/scijava/ops/matcher/OpCandidate.java
+++ b/src/main/java/org/scijava/ops/matcher/OpCandidate.java
@@ -53,8 +53,6 @@ public class OpCandidate {
 	public static enum StatusCode {
 		MATCH, //
 		INVALID_STRUCT, //
-		TOO_FEW_OUTPUTS, //
-		TOO_MANY_OUTPUTS,
 		OUTPUT_TYPES_DO_NOT_MATCH, //
 		TOO_MANY_ARGS, //
 		TOO_FEW_ARGS, //
@@ -167,9 +165,6 @@ public class OpCandidate {
 				sb.append("\n\t");
 				sb.append(vp.getMessage());
 			}
-			break;
-		case TOO_FEW_OUTPUTS:
-			sb.append("Too few outputs");
 			break;
 		case OUTPUT_TYPES_DO_NOT_MATCH:
 			sb.append("Output types do not match");

--- a/src/main/java/org/scijava/ops/matcher/OpClassInfo.java
+++ b/src/main/java/org/scijava/ops/matcher/OpClassInfo.java
@@ -32,7 +32,6 @@ package org.scijava.ops.matcher;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
-import java.util.List;
 
 import org.scijava.core.Priority;
 import org.scijava.ops.OpUtils;
@@ -40,7 +39,6 @@ import org.scijava.ops.core.Op;
 import org.scijava.param.ParameterStructs;
 import org.scijava.param.ValidityException;
 import org.scijava.plugin.Plugin;
-import org.scijava.struct.Member;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
 import org.scijava.util.Types;
@@ -61,6 +59,7 @@ public class OpClassInfo implements OpInfo {
 		this.opClass = opClass;
 		try {
 			struct = ParameterStructs.structOf(opClass);
+			OpUtils.checkHasSingleOutput(struct);
 		} catch (ValidityException e) {
 			validityException = e;
 		} 
@@ -78,16 +77,6 @@ public class OpClassInfo implements OpInfo {
 	@Override
 	public Struct struct() {
 		return struct;
-	}
-
-	@Override
-	public List<Member<?>> inputs() {
-		return OpUtils.inputs(struct());
-	}
-
-	@Override
-	public List<Member<?>> outputs() {
-		return OpUtils.outputs(struct());
 	}
 
 	@Override

--- a/src/main/java/org/scijava/ops/matcher/OpFieldInfo.java
+++ b/src/main/java/org/scijava/ops/matcher/OpFieldInfo.java
@@ -69,6 +69,7 @@ public class OpFieldInfo implements OpInfo {
 		this.field = field;
 		try {
 			struct = ParameterStructs.structOf(field.getDeclaringClass(), field);
+			OpUtils.checkHasSingleOutput(struct);
 			if (!Modifier.isStatic(field.getModifiers())) {
 				instance = field.getDeclaringClass().newInstance();
 			}

--- a/src/main/java/org/scijava/ops/matcher/OpInfo.java
+++ b/src/main/java/org/scijava/ops/matcher/OpInfo.java
@@ -30,8 +30,8 @@ public interface OpInfo {
 	}
 
 	/** Gets the op's output parameters. */
-	default List<Member<?>> outputs() {
-		return OpUtils.outputs(struct());
+	default Member<?> output() {
+		return OpUtils.outputs(struct()).get(0);
 	}
 
 	/** The op's priority. */

--- a/src/main/java/org/scijava/ops/matcher/OpRef.java
+++ b/src/main/java/org/scijava/ops/matcher/OpRef.java
@@ -60,19 +60,19 @@ public class OpRef {
 	private final Type[] types;
 
 	/** The op's output parameter types, or null for no constraints. */
-	private final Type[] outTypes;
+	private final Type outType;
 
 	/** Arguments to be passed to the op. */
 	private final Type[] args;
 
 	// -- Static construction methods --
 
-	public static OpRef fromTypes(final Type[] types, final Type[] outTypes, final Type... args) {
-		return new OpRef(null, filterNulls(types), filterNulls(outTypes), filterNulls(args));
+	public static OpRef fromTypes(final Type[] types, final Type outType, final Type... args) {
+		return new OpRef(null, filterNulls(types), outType, filterNulls(args));
 	}
 
-	public static OpRef fromTypes(final String name, final Type[] types, final Type[] outTypes, final Type... args) {
-		return new OpRef(name, filterNulls(types), filterNulls(outTypes), filterNulls(args));
+	public static OpRef fromTypes(final String name, final Type[] types, final Type outType, final Type... args) {
+		return new OpRef(name, filterNulls(types), outType, filterNulls(args));
 	}
 
 	// -- Constructor --
@@ -84,15 +84,15 @@ public class OpRef {
 	 *            name of the op, or null for any name.
 	 * @param types
 	 *            types which the ops must match.
-	 * @param outTypes
-	 *            the op's required output types.
+	 * @param outType
+	 *            the op's required output type.
 	 * @param args
 	 *            arguments to the op.
 	 */
-	public OpRef(final String name, final Type[] types, final Type[] outTypes, final Type[] args) {
+	public OpRef(final String name, final Type[] types, final Type outType, final Type[] args) {
 		this.name = name;
 		this.types = types;
-		this.outTypes = outTypes;
+		this.outType = outType;
 		this.args = args;
 	}
 
@@ -109,11 +109,10 @@ public class OpRef {
 	}
 
 	/**
-	 * Gets the op's output types (one constraint per output), or null for no
-	 * constraints.
+	 * Gets the op's output type constraint, or null for no constraint.
 	 */
-	public Type[] getOutTypes() {
-		return outTypes.clone();
+	public Type getOutType() {
+		return outType;
 	}
 
 	/** Gets the op's arguments. */
@@ -172,12 +171,10 @@ public class OpRef {
 			n += arg.getTypeName();
 			n += "\n";
 		}
-		n += "Output Types: \n";
-		for (Type out : outTypes) {
-			n += "\t\t* ";
-			n += out.getTypeName();
-			n += "\n";
-		}
+		n += "Output Type: \n";
+		n += "\t\t* ";
+		n += outType.getTypeName();
+		n += "\n";
 		return n.substring(0, n.length() - 1);
 	}
 
@@ -194,7 +191,7 @@ public class OpRef {
 			return false;
 		if (!Objects.equals(types, other.types))
 			return false;
-		if (!Objects.equals(outTypes, other.outTypes))
+		if (!Objects.equals(outType, other.outType))
 			return false;
 		if (!Objects.equals(args, other.args))
 			return false;
@@ -203,7 +200,7 @@ public class OpRef {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name, types, outTypes, args);
+		return Objects.hash(name, types, outType, args);
 	}
 
 	// -- Utility methods --

--- a/src/main/java/org/scijava/ops/transform/KnowsTypes.java
+++ b/src/main/java/org/scijava/ops/transform/KnowsTypes.java
@@ -5,5 +5,5 @@ import org.scijava.ops.types.Nil;
 public interface KnowsTypes {
 	Nil<?>[] inTypes();
 
-	Nil<?>[] outTypes();
+	Nil<?> outType();
 }

--- a/src/main/java/org/scijava/ops/transform/OpRefTransformUtils.java
+++ b/src/main/java/org/scijava/ops/transform/OpRefTransformUtils.java
@@ -80,11 +80,11 @@ public final class OpRefTransformUtils {
 		// From the functional type we know how many there must be.
 		Type[] args = toRef.getArgs();
 		boolean argsChanged = TypeModUtils.unliftTypes(args, unliftRawClass, argIndices);
-		Type[] outs = toRef.getOutTypes();
+		Type[] outs = new Type[] { toRef.getOutType() };
 		boolean outsChanged = TypeModUtils.unliftTypes(outs, unliftRawClass, outputIndices);
 
 		if (typesChanged && argsChanged && outsChanged) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, outs, args);
+			return OpRef.fromTypes(toRef.getName(), refTypes, outs[0], args);
 		}
 		return null;
 	}

--- a/src/main/java/org/scijava/ops/transform/OpRunner.java
+++ b/src/main/java/org/scijava/ops/transform/OpRunner.java
@@ -8,8 +8,7 @@ public interface OpRunner<O> extends KnowsTypes {
 	Object getAdaptedOp();
 
 	@Override
-	default Nil<?>[] outTypes() {
-		return new Nil<?>[] { new Nil<O>() {
-		} };
+	default Nil<?> outType() {
+		return new Nil<O>() {};
 	}
 }

--- a/src/main/java/org/scijava/ops/transform/functional/BiComputerToBiFunctionTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/BiComputerToBiFunctionTransformer.java
@@ -8,20 +8,19 @@ import org.scijava.ops.core.computer.BiComputer;
 import org.scijava.ops.matcher.OpRef;
 import org.scijava.ops.transform.OpTransformer;
 import org.scijava.ops.transform.TypeModUtils;
+import org.scijava.ops.types.Nil;
 import org.scijava.ops.util.Adapt;
 import org.scijava.ops.util.Functions;
 import org.scijava.plugin.Plugin;
-import org.scijava.ops.types.Nil;
 
 @Plugin(type = OpTransformer.class)
 public class BiComputerToBiFunctionTransformer implements FunctionalTypeTransformer {
 
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) throws Exception {
-		Type[] outTypes = ref.getOutTypes();
 		Type[] argTypes = ref.getArgs();
 		BiFunction srcOp = Functions.binary(opService, "create", Nil.of(argTypes[0]), Nil.of(argTypes[1]),
-				Nil.of(outTypes[0]));
+				Nil.of(ref.getOutType()));
 		return Adapt.Computers.asBiFunction((BiComputer) src, srcOp);
 	}
 
@@ -37,11 +36,11 @@ public class BiComputerToBiFunctionTransformer implements FunctionalTypeTransfor
 
 	@Override
 	public Type[] getTransformedArgTypes(OpRef toRef) {
-		return TypeModUtils.insert(toRef.getArgs(), toRef.getOutTypes()[0], 2);
+		return TypeModUtils.insert(toRef.getArgs(), toRef.getOutType(), 2);
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 }

--- a/src/main/java/org/scijava/ops/transform/functional/BiComputerToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/BiComputerToOpRunnerTransformer.java
@@ -24,7 +24,6 @@ public class BiComputerToOpRunnerTransformer implements FunctionalTypeTransforme
 	@SuppressWarnings("unchecked")
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) {
-		Type[] outTypes = ref.getOutTypes();
 		return OpRunners.Computers.toRunner((BiComputer) src);
 	}
 
@@ -44,8 +43,8 @@ public class BiComputerToOpRunnerTransformer implements FunctionalTypeTransforme
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +65,7 @@ public class BiComputerToOpRunnerTransformer implements FunctionalTypeTransforme
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/BiFunctionToBiComputerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/BiFunctionToBiComputerTransformer.java
@@ -9,18 +9,18 @@ import org.scijava.ops.core.computer.Computer;
 import org.scijava.ops.matcher.OpRef;
 import org.scijava.ops.transform.OpTransformer;
 import org.scijava.ops.transform.TypeModUtils;
+import org.scijava.ops.types.Nil;
 import org.scijava.ops.util.Adapt;
 import org.scijava.ops.util.Computers;
 import org.scijava.plugin.Plugin;
-import org.scijava.ops.types.Nil;
 
 @Plugin(type = OpTransformer.class)
 public class BiFunctionToBiComputerTransformer implements FunctionalTypeTransformer {
 
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) {
-		Type[] outTypes = ref.getOutTypes();
-		Computer copy = Computers.unary(opService, "copy", Nil.of(outTypes[0]), Nil.of(outTypes[0]));
+		Type outType = ref.getOutType();
+		Computer copy = Computers.unary(opService, "copy", Nil.of(outType), Nil.of(outType));
 		return Adapt.Functions.asBiComputer((BiFunction) src, copy);
 	}
 
@@ -40,7 +40,7 @@ public class BiFunctionToBiComputerTransformer implements FunctionalTypeTransfor
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 }

--- a/src/main/java/org/scijava/ops/transform/functional/BiFunctionToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/BiFunctionToOpRunnerTransformer.java
@@ -43,8 +43,8 @@ public class BiFunctionToOpRunnerTransformer implements FunctionalTypeTransforme
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class BiFunctionToOpRunnerTransformer implements FunctionalTypeTransforme
 		// OpRunner) into one array so that we can use them to parameterize the
 		// BiFunction.
 		Type[] toParamTypes = Stream
-				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Arrays.stream(getTransformedOutputTypes(toRef)))
+				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Stream.of(getTransformedOutputType(toRef)))
 				.toArray(Type[]::new);
 
 		// parameterize the OpRef types with the 3 BiFunction type parameters
@@ -64,7 +64,7 @@ public class BiFunctionToOpRunnerTransformer implements FunctionalTypeTransforme
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/BiInplaceFirstToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/BiInplaceFirstToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class BiInplaceFirstToOpRunnerTransformer implements FunctionalTypeTransf
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +66,7 @@ public class BiInplaceFirstToOpRunnerTransformer implements FunctionalTypeTransf
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/BiInplaceSecondToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/BiInplaceSecondToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class BiInplaceSecondToOpRunnerTransformer implements FunctionalTypeTrans
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +66,7 @@ public class BiInplaceSecondToOpRunnerTransformer implements FunctionalTypeTrans
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Computer3ToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Computer3ToOpRunnerTransformer.java
@@ -24,7 +24,6 @@ public class Computer3ToOpRunnerTransformer implements FunctionalTypeTransformer
 	@SuppressWarnings("unchecked")
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) {
-		Type[] outTypes = ref.getOutTypes();
 		return OpRunners.Computers.toRunner((Computer3) src);
 	}
 
@@ -44,8 +43,8 @@ public class Computer3ToOpRunnerTransformer implements FunctionalTypeTransformer
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +65,7 @@ public class Computer3ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Computer4ToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Computer4ToOpRunnerTransformer.java
@@ -24,7 +24,6 @@ public class Computer4ToOpRunnerTransformer implements FunctionalTypeTransformer
 	@SuppressWarnings("unchecked")
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) {
-		Type[] outTypes = ref.getOutTypes();
 		return OpRunners.Computers.toRunner((Computer4) src);
 	}
 
@@ -44,8 +43,8 @@ public class Computer4ToOpRunnerTransformer implements FunctionalTypeTransformer
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +65,7 @@ public class Computer4ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Computer5ToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Computer5ToOpRunnerTransformer.java
@@ -24,7 +24,6 @@ public class Computer5ToOpRunnerTransformer implements FunctionalTypeTransformer
 	@SuppressWarnings("unchecked")
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) {
-		Type[] outTypes = ref.getOutTypes();
 		return OpRunners.Computers.toRunner((Computer5) src);
 	}
 
@@ -44,8 +43,8 @@ public class Computer5ToOpRunnerTransformer implements FunctionalTypeTransformer
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +65,7 @@ public class Computer5ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/ComputerToFunctionTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/ComputerToFunctionTransformer.java
@@ -8,19 +8,18 @@ import org.scijava.ops.core.computer.Computer;
 import org.scijava.ops.matcher.OpRef;
 import org.scijava.ops.transform.OpTransformer;
 import org.scijava.ops.transform.TypeModUtils;
+import org.scijava.ops.types.Nil;
 import org.scijava.ops.util.Adapt;
 import org.scijava.ops.util.Functions;
 import org.scijava.plugin.Plugin;
-import org.scijava.ops.types.Nil;
 
 @Plugin(type = OpTransformer.class)
 public class ComputerToFunctionTransformer implements FunctionalTypeTransformer {
 	
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) throws Exception {
-		Type[] outTypes = ref.getOutTypes();
 		Type[] argTypes = ref.getArgs();
-		Function srcOp = Functions.unary(opService, "create", Nil.of(argTypes[0]), Nil.of(outTypes[0]));
+		Function srcOp = Functions.unary(opService, "create", Nil.of(argTypes[0]), Nil.of(ref.getOutType()));
 		return Adapt.Computers.asFunction((Computer) src, srcOp);
 	}
 
@@ -36,11 +35,11 @@ public class ComputerToFunctionTransformer implements FunctionalTypeTransformer 
 
 	@Override
 	public Type[] getTransformedArgTypes(OpRef toRef) {
-		return TypeModUtils.insert(toRef.getArgs(), toRef.getOutTypes()[0], 1);
+		return TypeModUtils.insert(toRef.getArgs(), toRef.getOutType(), 1);
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 }

--- a/src/main/java/org/scijava/ops/transform/functional/ComputerToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/ComputerToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class ComputerToOpRunnerTransformer implements FunctionalTypeTransformer 
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +66,7 @@ public class ComputerToOpRunnerTransformer implements FunctionalTypeTransformer 
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Function3ToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Function3ToOpRunnerTransformer.java
@@ -43,8 +43,8 @@ public class Function3ToOpRunnerTransformer implements FunctionalTypeTransformer
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class Function3ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// OpRunner) into one array so that we can use them to parameterize the
 		// BiFunction.
 		Type[] toParamTypes = Stream
-				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Arrays.stream(getTransformedOutputTypes(toRef)))
+				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Stream.of(getTransformedOutputType(toRef)))
 				.toArray(Type[]::new);
 
 		// parameterize the OpRef types with the 3 BiFunction type parameters
@@ -64,7 +64,7 @@ public class Function3ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Function4ToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Function4ToOpRunnerTransformer.java
@@ -43,8 +43,8 @@ public class Function4ToOpRunnerTransformer implements FunctionalTypeTransformer
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class Function4ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// OpRunner) into one array so that we can use them to parameterize the
 		// BiFunction.
 		Type[] toParamTypes = Stream
-				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Arrays.stream(getTransformedOutputTypes(toRef)))
+				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Stream.of(getTransformedOutputType(toRef)))
 				.toArray(Type[]::new);
 
 		// parameterize the OpRef types with the 3 BiFunction type parameters
@@ -64,7 +64,7 @@ public class Function4ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Function5ToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Function5ToOpRunnerTransformer.java
@@ -43,8 +43,8 @@ public class Function5ToOpRunnerTransformer implements FunctionalTypeTransformer
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class Function5ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// OpRunner) into one array so that we can use them to parameterize the
 		// BiFunction.
 		Type[] toParamTypes = Stream
-				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Arrays.stream(getTransformedOutputTypes(toRef)))
+				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Stream.of(getTransformedOutputType(toRef)))
 				.toArray(Type[]::new);
 
 		// parameterize the OpRef types with the 3 BiFunction type parameters
@@ -64,7 +64,7 @@ public class Function5ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Function6ToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Function6ToOpRunnerTransformer.java
@@ -43,8 +43,8 @@ public class Function6ToOpRunnerTransformer implements FunctionalTypeTransformer
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class Function6ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// OpRunner) into one array so that we can use them to parameterize the
 		// BiFunction.
 		Type[] toParamTypes = Stream
-				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Arrays.stream(getTransformedOutputTypes(toRef)))
+				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Stream.of(getTransformedOutputType(toRef)))
 				.toArray(Type[]::new);
 
 		// parameterize the OpRef types with the 3 BiFunction type parameters
@@ -64,7 +64,7 @@ public class Function6ToOpRunnerTransformer implements FunctionalTypeTransformer
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/FunctionToComputerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/FunctionToComputerTransformer.java
@@ -8,18 +8,18 @@ import org.scijava.ops.core.computer.Computer;
 import org.scijava.ops.matcher.OpRef;
 import org.scijava.ops.transform.OpTransformer;
 import org.scijava.ops.transform.TypeModUtils;
+import org.scijava.ops.types.Nil;
 import org.scijava.ops.util.Adapt;
 import org.scijava.ops.util.Computers;
 import org.scijava.plugin.Plugin;
-import org.scijava.ops.types.Nil;
 
 @Plugin(type = OpTransformer.class)
 public class FunctionToComputerTransformer implements FunctionalTypeTransformer {
 
 	@Override
 	public Object transform(OpService opService, OpRef ref, Object src) {
-		Type[] outTypes = ref.getOutTypes();
-		Computer copy = Computers.unary(opService, "copy", Nil.of(outTypes[0]), Nil.of(outTypes[0]));
+		Type outType = ref.getOutType();
+		Computer copy = Computers.unary(opService, "copy", Nil.of(outType), Nil.of(outType));
 		return Adapt.Functions.asComputer((Function) src, copy);
 	}
 
@@ -39,7 +39,7 @@ public class FunctionToComputerTransformer implements FunctionalTypeTransformer 
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 }

--- a/src/main/java/org/scijava/ops/transform/functional/FunctionToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/FunctionToOpRunnerTransformer.java
@@ -38,8 +38,8 @@ public class FunctionToOpRunnerTransformer implements FunctionalTypeTransformer 
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 	
 	@Override
@@ -49,7 +49,7 @@ public class FunctionToOpRunnerTransformer implements FunctionalTypeTransformer 
 		// OpRunner) into one array so that we can use them to parameterize the
 		// BiFunction.
 		Type[] toParamTypes = Stream
-				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Arrays.stream(getTransformedOutputTypes(toRef)))
+				.concat(Arrays.stream(getTransformedArgTypes(toRef)), Stream.of(getTransformedOutputType(toRef)))
 				.toArray(Type[]::new);
 
 		// parameterize the OpRef types with the 3 BiFunction type parameters
@@ -59,7 +59,7 @@ public class FunctionToOpRunnerTransformer implements FunctionalTypeTransformer 
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/FunctionalTypeTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/FunctionalTypeTransformer.java
@@ -21,7 +21,7 @@ public interface FunctionalTypeTransformer extends OpTransformer {
 		if(Types.raw(refTypes[0]) != targetClass()) return null;
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;
@@ -52,5 +52,5 @@ public interface FunctionalTypeTransformer extends OpTransformer {
 	 * @return
 	 * @see OpTransformer#getRefTransformingTo(OpRef)
 	 */
-	Type[] getTransformedOutputTypes(OpRef targetRef);
+	Type getTransformedOutputType(OpRef targetRef);
 }

--- a/src/main/java/org/scijava/ops/transform/functional/Inplace3FirstToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Inplace3FirstToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class Inplace3FirstToOpRunnerTransformer implements FunctionalTypeTransfo
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -62,7 +62,7 @@ public class Inplace3FirstToOpRunnerTransformer implements FunctionalTypeTransfo
 
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Inplace3SecondToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Inplace3SecondToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class Inplace3SecondToOpRunnerTransformer implements FunctionalTypeTransf
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -62,7 +62,7 @@ public class Inplace3SecondToOpRunnerTransformer implements FunctionalTypeTransf
 
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Inplace4FirstToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Inplace4FirstToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class Inplace4FirstToOpRunnerTransformer implements FunctionalTypeTransfo
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +66,7 @@ public class Inplace4FirstToOpRunnerTransformer implements FunctionalTypeTransfo
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/Inplace5FirstToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/Inplace5FirstToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class Inplace5FirstToOpRunnerTransformer implements FunctionalTypeTransfo
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +66,7 @@ public class Inplace5FirstToOpRunnerTransformer implements FunctionalTypeTransfo
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/functional/InplaceToOpRunnerTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/functional/InplaceToOpRunnerTransformer.java
@@ -44,8 +44,8 @@ public class InplaceToOpRunnerTransformer implements FunctionalTypeTransformer {
 	}
 
 	@Override
-	public Type[] getTransformedOutputTypes(OpRef toRef) {
-		return toRef.getOutTypes();
+	public Type getTransformedOutputType(OpRef toRef) {
+		return toRef.getOutType();
 	}
 
 	@Override
@@ -66,7 +66,7 @@ public class InplaceToOpRunnerTransformer implements FunctionalTypeTransformer {
 		// from here it is the s
 		boolean hit = TypeModUtils.replaceRawTypes(refTypes, targetClass(), srcClass());
 		if (hit) {
-			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputTypes(toRef),
+			return OpRef.fromTypes(toRef.getName(), refTypes, getTransformedOutputType(toRef),
 					getTransformedArgTypes(toRef));
 		}
 		return null;

--- a/src/main/java/org/scijava/ops/transform/lift/LiftFunctionToArrayTransformer.java
+++ b/src/main/java/org/scijava/ops/transform/lift/LiftFunctionToArrayTransformer.java
@@ -16,7 +16,7 @@ public class LiftFunctionToArrayTransformer implements OpTransformer {
 
 	@Override
 	public Object transform(OpService opService, OpRef targetRef, Object src) {
-		Class<?> outRaw = Types.raw(getRefTransformingTo(targetRef).getOutTypes()[0]);
+		Class<?> outRaw = Types.raw(getRefTransformingTo(targetRef).getOutType());
 		return Maps.Functions.Arrays.liftBoth((Function) src, outRaw);
 	}
 

--- a/src/main/java/org/scijava/ops/util/Computers.java
+++ b/src/main/java/org/scijava/ops/util/Computers.java
@@ -35,7 +35,7 @@ public class Computers {
 				opName, //
 				computerNil, //
 				new Nil[] { outputType }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -53,7 +53,7 @@ public class Computers {
 				opName, //
 				computerNil, //
 				new Nil[] { inputType, outputType }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -73,7 +73,7 @@ public class Computers {
 				opName, //
 				computerNil, //
 				new Nil[] { input1Type, input2Type, outputType }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -93,7 +93,7 @@ public class Computers {
 				opName, //
 				computerNil, //
 				new Nil[] { input1Type, input2Type, input3Type, outputType }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -113,7 +113,7 @@ public class Computers {
 				opName, //
 				computerNil, //
 				new Nil[] { input1Type, input2Type, input3Type, input4Type, outputType }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -134,7 +134,7 @@ public class Computers {
 				opName, //
 				computerNil, //
 				new Nil[] { input1Type, input2Type, input3Type, input4Type, input5Type, outputType }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 

--- a/src/main/java/org/scijava/ops/util/Functions.java
+++ b/src/main/java/org/scijava/ops/util/Functions.java
@@ -35,7 +35,7 @@ public class Functions {
 				opName, //
 				functionNil, //
 				new Nil[] { inputType }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -55,7 +55,7 @@ public class Functions {
 				opName, //
 				functionNil, //
 				new Nil[] { input1Type, input2Type }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -75,7 +75,7 @@ public class Functions {
 				opName, //
 				functionNil, //
 				new Nil[] { input1Type, input2Type, input3Type }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 
@@ -95,7 +95,7 @@ public class Functions {
 				opName, //
 				functionNil, //
 				new Nil[] { input1Type, input2Type, input3Type, input4Type }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 	
@@ -115,7 +115,7 @@ public class Functions {
 				opName, //
 				functionNil, //
 				new Nil[] { input1Type, input2Type, input3Type, input4Type, input5Type }, //
-				new Nil[] { outputType }, //
+				outputType, //
 				secondaryArgs);
 	}
 }

--- a/src/main/java/org/scijava/ops/util/Inplaces.java
+++ b/src/main/java/org/scijava/ops/util/Inplaces.java
@@ -51,7 +51,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { inputOutputType }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -70,7 +70,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { inputOutputType, input2Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -88,8 +88,8 @@ public class Inplaces {
 		return ops.findOp( //
 				opName, //
 				inplaceNil, //
-				new Nil[] { inputOutputType, input1Type }, //
-				new Nil[] { inputOutputType }, //
+				new Nil[] { input1Type, inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -109,7 +109,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { inputOutputType, input2Type, input3Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -129,7 +129,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, inputOutputType, input3Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -149,7 +149,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, inputOutputType }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -169,7 +169,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { inputOutputType, input2Type, input3Type, input4Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -189,7 +189,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, inputOutputType, input3Type, input4Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -209,7 +209,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, inputOutputType, input4Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -229,7 +229,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, input3Type, inputOutputType }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -249,7 +249,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { inputOutputType, input2Type, input3Type, input4Type, input5Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -269,7 +269,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, inputOutputType, input3Type, input4Type, input5Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -289,7 +289,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, inputOutputType, input4Type, input5Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -309,7 +309,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, input3Type, inputOutputType, input5Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -329,7 +329,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, input3Type, input4Type, inputOutputType }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 
@@ -350,7 +350,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { inputOutputType, input2Type, input3Type, input4Type, input5Type, input6Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 	
@@ -371,7 +371,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, inputOutputType, input3Type, input4Type, input5Type, input6Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 	
@@ -392,7 +392,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, inputOutputType, input4Type, input5Type, input6Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 	
@@ -413,7 +413,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, input3Type, inputOutputType, input5Type, input6Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 	
@@ -434,7 +434,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, input3Type, input4Type, inputOutputType, input6Type }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 	
@@ -455,7 +455,7 @@ public class Inplaces {
 				opName, //
 				inplaceNil, //
 				new Nil[] { input1Type, input2Type, input3Type, input4Type, input5Type, inputOutputType }, //
-				new Nil[] { inputOutputType }, //
+				inputOutputType, //
 				secondaryArgs);
 	}
 }


### PR DESCRIPTION
This PR removes the support for secondary Op outputs. Both OpRef and OpInfo only specify single outputs from now on. Op matching and transformation are adapted accordingly. Also, validation is added to enforce this new constraint during Op discovery and Op dependency resolution.